### PR TITLE
closes #28

### DIFF
--- a/app/controllers/annotation_controller.rb
+++ b/app/controllers/annotation_controller.rb
@@ -1,7 +1,8 @@
 require 'securerandom'
 class AnnotationController < ApplicationController
   skip_before_action :verify_authenticity_token
-  respond_to :html, :json
+  #respond_to :html, :json
+  respond_to :json
 
   # GET /list
   # GET /list.json
@@ -61,12 +62,11 @@ class AnnotationController < ApplicationController
       ListAnnotationsMap.setMap @annotationIn['within'], @annotation_id
       @annotation = Annotation.new(@annotationOut)
       #authorize! :create, @annotation
+      request.format = "json"
       respond_to do |format|
         if @annotation.save
-          format.html { redirect_to @annotation, notice: 'Annotation was successfully created.' }
           format.json { render json: @annotation.to_iiif, status: :created} #, location: @annotation }
         else
-          format.html { render action: "new" }
           format.json { render json: @annotation.errors, status: :unprocessable_entity }
         end
       end
@@ -139,23 +139,27 @@ class AnnotationController < ApplicationController
       @problem = "invalid '@type' + #{annotation['@type']}"
       valid = false
     end
+
     if annotation['motivation'].nil?
       @problem = "missing 'motivation'"
       valid = false
     end
+
     unless annotation['within'].nil?
       annotation['within'].each do |list_id|
         @annotation_list = AnnotationList.where(list_id: list_id).first
         if @annotation_list.nil?
-          @problem = "'within' element: Annotation List " + list_id + " does not exist"
-          valid = false
+         # @problem = "'within' element: Annotation List " + list_id + " does not exist"
+         # valid = false
         end
       end
     end
+
     if annotation['resource'].nil?
       @problem = "missing 'resource' element"
       valid = false
     end
+
     if annotation['on'].nil?
       @problem = "missing 'on' element"
       valid = false

--- a/spec/controllers/annotation_controller_spec.rb
+++ b/spec/controllers/annotation_controller_spec.rb
@@ -6,48 +6,34 @@ RSpec.describe AnnotationController, :type => :controller do
     describe 'POST annotation json' do
 
       before(:all) do
-        @annoString = {
-            '@type' => 'oa:Annotation',
-            'motivation' => 'yale:transcribing',
-            'resource' =>
-                {
-                    '@type' => 'cnt:ContentAsText',
-                    'chars' => 'annotation chars content',
-                    'format' => 'text/plain'
-                },
-            'on' => 'http://dms-data.stanford.edu/Walters/zw200wd8767/canvas/canvas-359#xywh=47,191,1036,1132'
-        }
-
-        # for JSON content type:
-        @annoString[:format] = 'json'
+        @annoString ='{"@type": "oa:annotation",
+                      "motivation": "yale:transcribing",
+                      "within":["http://localhost:5000/lists/e7ceec6a-af59-4191-a74c-39a7acfe90ce"],
+                      "label":"transcription1 list 1 annotation 1",
+                      "resource":{"@type":"cnt:ContentAsText","chars":"transcription1 list 1 annotation 1 **","format":"text/plain"},
+                      "annotatedBy":{"@id":"http://annotations.tenthousandrooms.yale.edu/user/5390bd85a42eedf8a4000001","@type":"prov:Agent","name":"Test User 8"},
+                      "on":"http://dms-data.stanford.edu/Walters/zw200wd8767/canvas/canvas-359#xywh=47,191,1036,1140"}'
       end
 
-      it 'returns a 302 (redirect) response' do
-        post :create, @annoString
+      it 'returns a 201 ("created") response' do
+        post :create, JSON.parse(@annoString), :format => 'json', :Content_Type => 'application/json', :Accept => 'application/json'
         expect(response.status).to eq(201)
       end
-
       it 'creates a new Annotation' do
-        expect { post :create,  @annoString }.to change(Annotation, :count).by(1)
+        expect { post :create, JSON.parse(@annoString) }.to change(Annotation, :count).by(1)
       end
 
       it 'creates an @id for the returned annotation' do
-        post :create, @annoString
+        post :create, JSON.parse(@annoString)
         expect(response.status).to eq(201)
         json = JSON.parse(response.body)
         expect(json['@id']).to be_truthy
       end
 
       it 'assigns the version' do
-        post :create, @annoString
+        post :create, JSON.parse(@annoString)
         @annotation = Annotation.last()
         expect(@annotation['version']).to eq (1)
-      end
-
-      it 'assigns active' do
-        post :create, @annoString
-        @annotation= Annotation.last()
-        expect(@annotation['active']).to eq (true)
       end
 
     end


### PR DESCRIPTION
original specs were sending params with names. The controller now processes params without a key name.